### PR TITLE
Streamline package manager calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Build parameters are specified via a YAML file. Cases can be arbitrarily nested.
   - `name` package name
   - `alias` package alias for package managers
   - `managers` list of package managers that provide the package
-- `bootstrap` list of package managers to bootstrap
+- `require` list of package managers to bootstrap
 - `bundle`
   - `manager` single package manager
   - `packages` list of package names to install
@@ -72,21 +72,24 @@ repo:
   remote: https://github.com/jcthomassie/dotfiles.git
 
 build:
-  # Bootstrap package managers
+  # Specify package managers
   - case:
     - positive:
-        spec:
-          platform: windows
+        spec: { distro: ubuntu }
         include:
-          - bootstrap:
+          - require:
+            - apt
+            - apt-get
+    - positive:
+        spec: { platform: windows }
+        include:
+          - require:
             - choco
-    - default:
+    - negative:
+        spec: { platform: windows }
         include:
-          - bootstrap:
+          - require:
             - brew
-
-  - bootstrap:
-    - cargo
 
   # Install packages
   - install:

--- a/test/build.yaml
+++ b/test/build.yaml
@@ -23,7 +23,7 @@ build:
               spec:
                 user: not_user
               include:
-                - bootstrap:
+                - require:
                   - choco
           - negative:
               spec:
@@ -39,7 +39,7 @@ build:
             - apt
             - apt-get
   # Top level instructions
-  - bootstrap:
+  - require:
     - cargo
     - brew
   - matrix:


### PR DESCRIPTION
- Only use package managers that are included via the "require" field
- Prune package manager list for each package depending on current build context