### PR TITLE
Move shell spec into run block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "yurt"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yurt"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Julian Thomassie <julianthomassie@gmail.com>"]
 repository = "https://github.com/jcthomassie/yurt"
 description = "Simple CLI tool for dotfile management."

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The order of build steps may change the resolved values.
 
 ```yaml
 ---
-version: 0.2.1
+version: 0.3.0
 build:
   # Require dotfile repo
   - repo:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Build parameters are specified via a YAML file. Cases can be arbitrarily nested.
 
 `version` yurt version for compatibility check
 
-`shell` set the shell for POSIX systems
-
 `build`
 
 - `repo`
@@ -57,6 +55,8 @@ Build parameters are specified via a YAML file. Cases can be arbitrarily nested.
   - `default` if none of the preceeding conditions are met
 - `link` list of symlinks to be applied
 - `run` shell command to run on install
+  - `shell` shell to run the command with
+  - `command` command to run
 - `install` list of packages to install
   - `name` package name
   - `managers` (optional) list of package managers that provide the package
@@ -71,7 +71,6 @@ The order of build steps may change the resolved values.
 ```yaml
 ---
 version: 0.2.1
-shell: zsh
 build:
   # Require dotfile repo
   - repo:
@@ -96,7 +95,14 @@ build:
         include:
           - require:
             - brew
-          - run: brew bundle --file ${{ dotfiles.path }}/.brewfile
+          # Run a command with a specific shell
+          - run:
+              shell: /usr/bin/bash
+              command: brew bundle --file ${{ dotfiles.path }}/.brewfile
+
+  # Run a command with the system default shell
+  - run: |
+      echo "hello world"
 
   # Install packages
   - install:

--- a/src/build.rs
+++ b/src/build.rs
@@ -2,7 +2,7 @@ use crate::condition::{Case, Locale, LocaleSpec};
 use crate::files::Link;
 use crate::package::{Package, PackageManager};
 use crate::repo::Repo;
-use crate::shell::{Shell, ShellCommand};
+use crate::shell::ShellCommand;
 use anyhow::{anyhow, bail, ensure, Context as AnyContext, Result};
 use clap::{crate_version, ArgMatches};
 use lazy_static::lazy_static;
@@ -241,7 +241,6 @@ pub struct ResolvedConfig {
     // Members should be treated as immutable
     context: Context,
     version: Option<String>,
-    shell: Shell,
     build: Vec<BuildUnit>,
 }
 
@@ -361,7 +360,6 @@ impl ResolvedConfig {
         }
         Config {
             version: self.version,
-            shell: Some(self.shell),
             build,
         }
     }
@@ -393,7 +391,6 @@ impl TryFrom<&ArgMatches> for ResolvedConfig {
 #[serde(deny_unknown_fields)]
 pub struct Config {
     version: Option<String>,
-    shell: Option<Shell>,
     build: Vec<BuildSpec>,
 }
 
@@ -435,7 +432,6 @@ impl Config {
         // Resolve build
         Ok(ResolvedConfig {
             version: self.version,
-            shell: self.shell.map_or_else(Shell::from_env, Shell::from),
             build: self.build.resolve_into_new(&mut context)?,
             context,
         })
@@ -474,7 +470,6 @@ pub mod tests {
         fn version_check() {
             let mut cfg = Config {
                 version: None,
-                shell: None,
                 build: Vec::new(),
             };
             assert!(!cfg.version_matches(true));

--- a/src/build.rs
+++ b/src/build.rs
@@ -2,7 +2,7 @@ use crate::condition::{Case, Locale, LocaleSpec};
 use crate::files::Link;
 use crate::package::{Package, PackageManager};
 use crate::repo::Repo;
-use crate::shell::{Shell, ShellSpec};
+use crate::shell::{Shell, ShellCommand};
 use anyhow::{anyhow, bail, ensure, Context as AnyContext, Result};
 use clap::{crate_version, ArgMatches};
 use lazy_static::lazy_static;
@@ -110,7 +110,7 @@ impl<T> Matrix<T> {
 pub enum BuildUnit {
     Repo(Repo),
     Link(Link),
-    Run(String),
+    Run(ShellCommand),
     Install(Package),
     Require(PackageManager),
 }
@@ -127,7 +127,7 @@ enum BuildSpec {
     Matrix(Matrix<Vec<BuildSpec>>),
     Case(Case<LocaleSpec, Vec<BuildSpec>>),
     Link(Vec<Link>),
-    Run(String),
+    Run(ShellCommand),
     Install(Vec<Package>),
     Require(Vec<PackageManager>),
 }
@@ -154,12 +154,6 @@ impl BuildSpec {
 
 pub trait Resolve {
     fn resolve(self, context: &mut Context) -> Result<BuildUnit>;
-}
-
-impl Resolve for String {
-    fn resolve(self, context: &mut Context) -> Result<BuildUnit> {
-        Ok(BuildUnit::Run(context.replace_variables(&self)?))
-    }
 }
 
 pub trait ResolveInto {
@@ -324,7 +318,7 @@ impl ResolvedConfig {
             match unit {
                 BuildUnit::Repo(repo) => drop(repo.require()?),
                 BuildUnit::Link(link) => link.link(clean)?,
-                BuildUnit::Run(cmd) => drop(self.shell.run(cmd.as_str())?),
+                BuildUnit::Run(cmd) => cmd.run()?,
                 BuildUnit::Install(package) => package.install()?,
                 BuildUnit::Require(manager) => manager.require()?,
             }
@@ -367,7 +361,7 @@ impl ResolvedConfig {
         }
         Config {
             version: self.version,
-            shell: Some(self.shell.into()),
+            shell: Some(self.shell),
             build,
         }
     }
@@ -397,9 +391,9 @@ impl TryFrom<&ArgMatches> for ResolvedConfig {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-struct Config {
+pub struct Config {
     version: Option<String>,
-    shell: Option<ShellSpec>,
+    shell: Option<Shell>,
     build: Vec<BuildSpec>,
 }
 
@@ -639,7 +633,7 @@ pub mod tests {
     #[test]
     fn matrix_length() {
         #[rustfmt::skip]
-        let matrix: Matrix<Vec<String>> = serde_yaml::from_str("
+        let matrix: Matrix<Vec<BuildSpec>> = serde_yaml::from_str("
             values:
               a: [1, 2, 3]
               b: [4, 5, 6]
@@ -652,7 +646,7 @@ pub mod tests {
     fn matrix_length_mismatch() {
         let mut context = get_context(&[]);
         #[rustfmt::skip]
-        let matrix: Matrix<Vec<String>> = serde_yaml::from_str("
+        let matrix: Matrix<Vec<BuildSpec>> = serde_yaml::from_str("
             values:
               a: [1, 2, 3]
               b: [4, 5, 6, 7]

--- a/test/invalid/parse/no_build.yaml
+++ b/test/invalid/parse/no_build.yaml
@@ -1,3 +1,2 @@
 ---
 version: 0.2.0
-shell: zsh

--- a/test/invalid/parse/unknown_key.yaml
+++ b/test/invalid/parse/unknown_key.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.1
-shell: zsh
 something: invalid
 build:
   include:

--- a/test/invalid/parse/unknown_key.yaml
+++ b/test/invalid/parse/unknown_key.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.3.0
 something: invalid
 build:
   include:

--- a/test/io/case/input.yaml
+++ b/test/io/case/input.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.0
-shell: zsh
 build:
   - case:
     - positive:

--- a/test/io/case/output.yaml
+++ b/test/io/case/output.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.0
-shell: zsh
 build:
   - install:
       - name: package_0

--- a/test/io/exclude/input.yaml
+++ b/test/io/exclude/input.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.1
-shell: zsh
 build:
   - run:
       shell: usr/bin/my-shell

--- a/test/io/exclude/input.yaml
+++ b/test/io/exclude/input.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.3.0
 build:
   - run:
       shell: usr/bin/my-shell

--- a/test/io/exclude/input.yaml
+++ b/test/io/exclude/input.yaml
@@ -2,7 +2,9 @@
 version: 0.2.1
 shell: zsh
 build:
-  - run: ""
+  - run:
+      shell: usr/bin/my-shell
+      command: something
   - link:
     - head: a
       tail: b

--- a/test/io/exclude/output.yaml
+++ b/test/io/exclude/output.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.1
-shell: zsh
 build:
   - run:
       shell: usr/bin/my-shell

--- a/test/io/exclude/output.yaml
+++ b/test/io/exclude/output.yaml
@@ -2,4 +2,6 @@
 version: 0.2.1
 shell: zsh
 build:
-  - run: ""
+  - run:
+      shell: usr/bin/my-shell
+      command: something

--- a/test/io/exclude/output.yaml
+++ b/test/io/exclude/output.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.3.0
 build:
   - run:
       shell: usr/bin/my-shell

--- a/test/io/include/input.yaml
+++ b/test/io/include/input.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.1
-shell: zsh
 build:
   - run:
       shell: /usr/bin/bash

--- a/test/io/include/input.yaml
+++ b/test/io/include/input.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.3.0
 build:
   - run:
       shell: /usr/bin/bash

--- a/test/io/include/input.yaml
+++ b/test/io/include/input.yaml
@@ -2,7 +2,9 @@
 version: 0.2.1
 shell: zsh
 build:
-  - run: ""
+  - run:
+      shell: /usr/bin/bash
+      command: my-command
   - link:
     - head: a
       tail: b

--- a/test/io/include/output.yaml
+++ b/test/io/include/output.yaml
@@ -2,7 +2,9 @@
 version: 0.2.1
 shell: zsh
 build:
-  - run: ""
+  - run:
+      shell: /usr/bin/bash
+      command: my-command
   - link:
       - head: a
         tail: b

--- a/test/io/include/output.yaml
+++ b/test/io/include/output.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.1
-shell: zsh
 build:
   - run:
       shell: /usr/bin/bash

--- a/test/io/include/output.yaml
+++ b/test/io/include/output.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.3.0
 build:
   - run:
       shell: /usr/bin/bash

--- a/test/io/matrix/input.yaml
+++ b/test/io/matrix/input.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.1.0
-shell: zsh
 build:
   - matrix:
       values:

--- a/test/io/matrix/output.yaml
+++ b/test/io/matrix/output.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.1.0
-shell: zsh
 build:
   - link:
       - head: dir_a/head_1

--- a/test/io/namespace/input.yaml
+++ b/test/io/namespace/input.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.0
-shell: bash
 build:
   - namespace:
       name: names

--- a/test/io/namespace/output.yaml
+++ b/test/io/namespace/output.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.0
-shell: bash
 build:
   - install:
       - name: package_2

--- a/test/io/packages/input.yaml
+++ b/test/io/packages/input.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.0 # becomes explicit string
-shell: zsh
 build:
   - install:
     - name: package_a

--- a/test/io/packages/output.yaml
+++ b/test/io/packages/output.yaml
@@ -1,6 +1,5 @@
 ---
 version: "0.0"
-shell: zsh
 build:
   - install:
       - name: package_a

--- a/test/io/packages_expanded/input.yaml
+++ b/test/io/packages_expanded/input.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.0 # becomes explicit string
-shell: zsh
 build:
   - install:
     - name: package_a

--- a/test/io/packages_expanded/output.yaml
+++ b/test/io/packages_expanded/output.yaml
@@ -1,6 +1,5 @@
 ---
 version: "0.0"
-shell: zsh
 build:
   - install:
       - name: package_a

--- a/test/io/repo/input.yaml
+++ b/test/io/repo/input.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.0
-shell: zsh
 build:
   - repo:
       path: /home/dotfiles

--- a/test/io/repo/output.yaml
+++ b/test/io/repo/output.yaml
@@ -1,6 +1,5 @@
 ---
 version: 0.2.0
-shell: zsh
 build:
   - repo:
       path: /home/dotfiles


### PR DESCRIPTION
- Specify "run" as string or struct
- Remove top level shell setting
- Bump version to 0.3.0 due to breaking change